### PR TITLE
Sostituito costruttore deprecato

### DIFF
--- a/widget/widget.php
+++ b/widget/widget.php
@@ -2,7 +2,7 @@
 
 class atWidget extends WP_Widget {
 
-    function atWidget() {
+    function __construct() {
 
         parent::__construct( 'atwidget', 'Amministrazione Trasparente', array( 'description' => 'Lista delle sezioni relative alla trasparenza' ) );
 


### PR DESCRIPTION
Il costruttore della classe atWidget produce un avviso in PHP7: "Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; atWidget has a deprecated constructor".
Questa modifica risolve il problema.

P.S. Complimenti per il progetto